### PR TITLE
JdbcSQLException when calling `exec` w/update or delete query map

### DIFF
--- a/src/oj/core.clj
+++ b/src/oj/core.clj
@@ -54,7 +54,7 @@
     (let [tuples (cond (:insert query)
                        (j/insert! db (:table query) (:insert query))
 
-                       (#{:update :delete} query)
+                       (or (:update query) (:delete query))
                        (j/execute! db [(sqlify query)])
 
                        :else


### PR DESCRIPTION
It appears to be the case that a recent commit modified the behavior of the `exec` function, causing update and delete-queries to use `j/query` instead of `j/execute!`. This ultimately results in a `JdbcSQLException`.

The offending line of code can be found [here](https://github.com/taylorlapeyre/oj/blob/master/src/oj/core.clj#L57). My patch modifies that line to read:

``` clojure
(or (:update query) (:delete query))
```

Using version 0.1.9 of oj, I was able to reproduce the failure with the following expressions:

``` clojure
(oj/exec {:update {:completed "true"}, :where {:id 2}, :table :todos} db-spec)
(oj/exec {:table :todos :delete true :where {:id 2}} db-spec)
```

Take care,

Erin
