### PR TITLE
Add delete modifier and update README to reflect API

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Of course, you can also perform all of the standard CRUD operations that you'd e
   (defn delete [id]
     (-> (db/query :users)
         (db/where {:id id})
-        (db/delete true)
+        (db/delete)
         (oj/exec db-config)))
   ```
 

--- a/src/oj/modifiers.clj
+++ b/src/oj/modifiers.clj
@@ -37,6 +37,11 @@
   [query updates]
   (assoc query :update updates))
 
+(defn delete
+  "Modifies the query map to include the :delete clause provided"
+  [query]
+  (assoc query :delete true))
+
 (defn join
   "Modifies the query map to include the :join clause provided. If no join
   columns are specified, it will make a guess:

--- a/test/oj/modifiers_test.clj
+++ b/test/oj/modifiers_test.clj
@@ -1,0 +1,9 @@
+(ns oj.modifiers-test
+  (:require [clojure.test :refer :all]
+            [oj.modifiers :refer :all]))
+
+(deftest update-query-map
+  (is (= (update {} {:foo "bar"}) {:update {:foo "bar"}})))
+
+(deftest delete-query-map
+  (is (= (delete {}) {:delete true})))


### PR DESCRIPTION
The README shows a delete modifier being used, but one doesn't seem to exist in `oj.modifiers`. This patch adds a `delete` function and updates the README. 

Note that the README demonstrated a signature that accepted (in addition to a query map) a boolean value. I can't think of an example where you'd want to pass `:delete false`, so I removed the second parameter and hard-coded `true`.

I also added a couple of tests for the modifiers stuff.

Take care, and keep up the good work!

Erin
