### PR TITLE
oj/core.clj: Trim extra spaces in sqlify

### DIFF
--- a/src/oj/core.clj
+++ b/src/oj/core.clj
@@ -32,9 +32,12 @@
                          (:update query) sql-update-generators
                          (:delete query) sql-delete-generators
                          :else           sql-select-generators)]
-    (trim (reduce str (interpose \space
-                      (for [gen generators]
-                        (gen query)))))))
+    (->> (for [gen generators]
+           (gen query))
+         (remove nil?)
+         (interpose \space)
+         (apply str)
+         (trim))))
 
 (defn exec
   "Given a query map and a database config, generates and runs SQL for the query


### PR DESCRIPTION
When SQLifying an expression, if any of the generators returned nil, skip that entirely, instead of adding a space.

The main purpose of this change is to make generator chaining produce more reliable output. For example, if we'd like to introduce `GROUP BY`, and place it before `ORDER BY`, if there's no grouping, without this change, we'd have an extra space before the `ORDER BY`, which would break tests.

This patch simply makes it so that such spaces are removed.
