### PR TITLE
Add a group-by generator

### DIFF
--- a/doc/SPEC
+++ b/doc/SPEC
@@ -57,6 +57,11 @@ following keys:
      :where {:age {:> 21 :< 18}}}
     SELECT * FROM users WHERE age > 21 AND age < 18
 
+  :group
+    (Vector)
+    Optional For: (:select)
+    A vector of SQL column names to group the query by.
+
   :order
     (Vector)
     Optional For: (:select)

--- a/src/oj/core.clj
+++ b/src/oj/core.clj
@@ -9,6 +9,7 @@
 (def sql-select-generators
   [gen/select
    gen/where
+   gen/group
    gen/order
    gen/limit])
 

--- a/src/oj/generators.clj
+++ b/src/oj/generators.clj
@@ -35,6 +35,12 @@
   (when-let [[col direction] order]
     (str "ORDER BY " (sql-val col) \space (sql-val direction))))
 
+(defn group
+  "Generates the GROUP BY part of a SQL statement from a query map."
+  [{:keys [group]}]
+  (when group
+    (str "GROUP BY " (sql-val group))))
+
 (defn where
   "Generates the WHERE part of a SQL statement from a query map."
   [{:keys [table where]}]

--- a/src/oj/validation.clj
+++ b/src/oj/validation.clj
@@ -5,7 +5,7 @@
   (let [message (str "The query map had a problem: " message)]
     (throw (Exception. message))))
 
-(defn validate-query-map [{:keys [table select insert where update delete join]}]
+(defn validate-query-map [{:keys [table select insert where group update delete join]}]
   "Analyzes a query map and throws an error when it finds malformed data."
   ; letfn is really ugly...
   (letfn [(validate-select []
@@ -49,6 +49,14 @@
                     (problem "Every value in a :where map must be either a string, number, or map.")))))
             true)
 
+          (validate-group []
+            (when-not (vector? group)
+              (problem ":group must be a vector."))
+            (when (empty? group)
+              (problem ":group must not be empty when present."))
+            (when-not (every? keyword? group)
+              (problem "Every value in a :group must be a keyword")))
+
           (validate-update []
             (when-not (map? update)
               (problem ":update must be a map."))
@@ -90,6 +98,7 @@
     (when select (validate-select))
     (when insert (validate-insert))
     (when update (validate-update))
+    (when group (validate-group))
     (when where (validate-where))
     (when delete (validate-delete))
     (when join (validate-join))

--- a/test/oj/core_test.clj
+++ b/test/oj/core_test.clj
@@ -34,6 +34,12 @@
                   :where {:id [1 2 3]}})
          "SELECT * FROM users WHERE users.id IN (1, 2, 3)")))
 
+(deftest select-statement-with-group-by
+  (is (= (sqlify {:table :orders
+                  :select [:order_id :price]
+                  :group [:order_id]})
+         "SELECT order_id, price FROM orders GROUP BY order_id")))
+
 (deftest insert-statement
   (is (= (sqlify {:table :users
                   :insert {:username "taylor" :password "password"}})


### PR DESCRIPTION
This implements a very simple `:group` generator. Depends on #10, for more reliable SQL string production.
