### PR TITLE
Support the HAVING clause

### DIFF
--- a/doc/SPEC
+++ b/doc/SPEC
@@ -61,6 +61,21 @@ following keys:
      :where {:age {:> 21 :< 18}}}
     SELECT * FROM users WHERE age > 21 AND age < 18
 
+  :having
+    (IPersistentMap)
+    Optional For: (:select)
+    A Clojure map containing column names and the corresponding values with which
+    to filter the table by, after aggregations. Values may be numbers, strings,
+    vectors or maps.
+
+    If the value of an item in :having is a map, it contain only the following keys:
+    [:< :> :not=]
+
+    {:table :orders
+     :group ['(sum :price)]
+     :having {'(sum :price) {:> 2}}}
+    SELECT * FROM orders GROUP BY sum(price) HAVING sum(price) > 2
+
   :group
     (Vector)
     Optional For: (:select)

--- a/src/oj/core.clj
+++ b/src/oj/core.clj
@@ -11,6 +11,7 @@
    gen/where
    gen/group
    gen/order
+   gen/having
    gen/limit])
 
 (def sql-insert-generators

--- a/src/oj/generators.clj
+++ b/src/oj/generators.clj
@@ -115,6 +115,14 @@
 
  (keyword (str (name table) "." (name col))))
 
+(make-filter
+ having
+ "Generates the HAVING part of a SQL statement from a query map."
+
+ (if (keyword? col)
+   (keyword (str (name table) "." (name col)))
+   col))
+
 (defn insert
   "Generates an INSERT SQL statement from a query map."
   [{:keys [table insert]}]

--- a/test/oj/core_test.clj
+++ b/test/oj/core_test.clj
@@ -47,6 +47,13 @@
                   :group [:order_id]})
          "SELECT order_id, sum(price) FROM orders GROUP BY order_id")))
 
+(deftest select-statement-with-having
+  (is (= (sqlify {:table :orders
+                  :select [:order_id '(sum :price)]
+                  :group [:order_id]
+                  :having {'(sum :price) {:> 2}}})
+         "SELECT order_id, sum(price) FROM orders GROUP BY order_id HAVING sum(price) > 2")))
+
 (deftest insert-statement
   (is (= (sqlify {:table :users
                   :insert {:username "taylor" :password "password"}})


### PR DESCRIPTION
Support for `HAVING` is implemented in this PR by turning the bulk of the `oj/generators/where` function into a macro (dcd10e0), and then implementing `HAVING` using that macro. The syntax is very close to that of `(where)`, but `(having)` allows aggregates too.

Documentation, tests and validation updated too.
